### PR TITLE
Added fallback typing for casesFn for arrays with length over 6

### DIFF
--- a/src/reducers/interfaces.ts
+++ b/src/reducers/interfaces.ts
@@ -46,6 +46,7 @@ export interface CasesFn {
     ],
     handler: Handler<S, P1 | P2 | P3 | P4 | P5 | P6>,
   ): Reducer<S, P1 | P2 | P3 | P4 | P5 | P6, any>;
+  <S>(actionCreator: [ActionCreator<any, any>], handler: Handler<S, any>): Reducer<S, any, any>;
 }
 
 /**


### PR DESCRIPTION
Useful for cases where a reducer is simply tracking mutexes and doesn't care about payload typing. The variadic case has multiple solutions, the nicest of which looks to be outlined here: https://github.com/Microsoft/TypeScript/issues/26980